### PR TITLE
Fix cache conflicts by using job-specific cache keys

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,8 +29,9 @@ jobs:
         path: |
           ~/.cache/go-build
           ~/go/pkg/mod
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        key: ${{ runner.os }}-go-test-${{ hashFiles('**/go.sum') }}
         restore-keys: |
+          ${{ runner.os }}-go-test-
           ${{ runner.os }}-go-
 
     - name: Download dependencies
@@ -80,8 +81,9 @@ jobs:
         path: |
           ~/.cache/go-build
           ~/go/pkg/mod
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        key: ${{ runner.os }}-go-lint-${{ hashFiles('**/go.sum') }}
         restore-keys: |
+          ${{ runner.os }}-go-lint-
           ${{ runner.os }}-go-
 
     - name: Download dependencies
@@ -187,8 +189,9 @@ jobs:
         path: |
           ~/.cache/go-build
           ~/go/pkg/mod
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        key: ${{ runner.os }}-go-build-${{ hashFiles('**/go.sum') }}
         restore-keys: |
+          ${{ runner.os }}-go-build-
           ${{ runner.os }}-go-
 
     - name: Download dependencies
@@ -227,8 +230,9 @@ jobs:
         path: |
           ~/.cache/go-build
           ~/go/pkg/mod
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        key: ${{ runner.os }}-go-integration-${{ hashFiles('**/go.sum') }}
         restore-keys: |
+          ${{ runner.os }}-go-integration-
           ${{ runner.os }}-go-
 
     - name: Download dependencies


### PR DESCRIPTION
- Add unique cache keys for each CI job (test, lint, build, integration)
- Prevents 'File exists' warnings from concurrent cache restoration
- Maintains fallback to shared cache with restore-keys hierarchy
- Improves build pipeline reliability and reduces cache conflicts

🤖 Generated with [Claude Code](https://claude.ai/code)