### PR TITLE
hotfix: Fix deployment module structure

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/samsoir/youtube-webhook
 
 go 1.23.0
 
-toolchain go1.23.0
-
 replace github.com/samsoir/youtube-webhook/function => ./function
 
 require (
@@ -42,7 +40,6 @@ require (
 	github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742 // indirect
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
 	github.com/spiffe/go-spiffe/v2 v2.5.0 // indirect
-	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/zeebo/errs v1.4.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/contrib/detectors/gcp v1.36.0 // indirect


### PR DESCRIPTION
## Problem

The deployment workflow failed after merging PR #23 due to incorrect module structure changes made during the integration test fix.

## Root Cause

During the integration test fix, we changed the function module name from `github.com/samsoir/youtube-webhook/function` to `github.com/samsoir/youtube-webhook`, which broke the deployment workflow that expects the original module structure.

## Solution

- Restored function module name to `github.com/samsoir/youtube-webhook/function`
- Fixed testutil imports to use proper module path
- Tests now pass through the Makefile which handles the module architecture correctly

## Testing

✅ Local tests pass: `make test`
✅ Module structure validated

This hotfix resolves the deployment failure while maintaining CI compatibility.

🤖 Generated with [Claude Code](https://claude.ai/code)