### PR TITLE
hotfix: Fix Terraform service account length validation error

### DIFF
--- a/terraform/scheduler.tf
+++ b/terraform/scheduler.tf
@@ -10,7 +10,7 @@ resource "google_project_service" "scheduler_api" {
 
 # Service account for Cloud Scheduler (with necessary permissions)
 resource "google_service_account" "scheduler_sa" {
-  account_id   = "yt-scheduler-${var.environment}-${local.unique_suffix}"
+  account_id   = "yt-sched-${substr(var.environment, 0, 4)}-${local.unique_suffix}"
   display_name = "YouTube Scheduler Service Account (${var.environment})"
   description  = "Service account for Cloud Scheduler to trigger subscription renewals (${var.environment})"
   project      = var.project_id


### PR DESCRIPTION
## Summary
- Fix Terraform plan failure due to service account ID length validation
- Shorten service account name from 31 to 22 characters to meet GCP requirements

## Root Cause
Terraform plan was failing with:
```
Error: "account_id" ("yt-scheduler-production-2dfc5d65") must be between 6 and 30 characters long
```

The service account ID `yt-scheduler-production-2dfc5d65` was 31 characters, exceeding GCP's 30 character limit.

## Solution
Changed the service account naming pattern:
- **Before**: `yt-scheduler-${var.environment}-${local.unique_suffix}` (31 chars for production)
- **After**: `yt-sched-${substr(var.environment, 0, 4)}-${local.unique_suffix}` (22 chars for production)

## Test plan
- [x] Verified new name length is within GCP limits (22 chars vs 30 max)
- [ ] Verify Terraform plan succeeds after merge
- [ ] Verify deployment completes successfully

This is the final fix needed to resolve the deployment failure after PR #38.

🤖 Generated with [Claude Code](https://claude.ai/code)