### PR TITLE
chore: Upgrade Go version from 1.23 to 1.24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
     branches: [ main, develop ]
 
 env:
-  GO_VERSION: 1.23
+  GO_VERSION: 1.24
 
 jobs:
   test:
@@ -72,7 +72,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.23'
+        go-version: '1.24'
 
     - name: Cache Go modules
       uses: actions/cache@v4

--- a/function/go.mod
+++ b/function/go.mod
@@ -1,6 +1,6 @@
 module github.com/samsoir/youtube-webhook/function
 
-go 1.23.0
+go 1.24.0
 
 require (
 	cloud.google.com/go/storage v1.55.0


### PR DESCRIPTION
## Summary
- Upgrade Go from 1.23 to 1.24 in go.mod and CI workflow
- Required to support cloud.google.com/go/storage v1.57.0 which has minimum Go 1.24 requirement
- Unblocks Dependabot PR #41 for storage library update

## Changes
- Updated `function/go.mod` to use Go 1.24.0
- Updated `.github/workflows/ci.yml` to use Go 1.24 in all jobs

## Test plan
- [x] CI workflow runs successfully with Go 1.24
- [ ] All tests pass
- [ ] After merge, rebase PR #41 to pick up this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)