### PR TITLE
fix: Change IAM binding to member to avoid resource conflicts

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -211,12 +211,13 @@ resource "google_cloudfunctions2_function" "youtube_webhook" {
   ]
 }
 
-# IAM binding to allow public access to the webhook
+# IAM member to allow public access to the webhook
 # Gen 2 Cloud Functions use Cloud Run underneath, so we need to grant roles/run.invoker
-resource "google_cloud_run_service_iam_binding" "webhook_invoker" {
+# Using iam_member instead of iam_binding to avoid conflicts with scheduler_invoker
+resource "google_cloud_run_service_iam_member" "webhook_public_invoker" {
   project  = google_cloudfunctions2_function.youtube_webhook.project
   location = google_cloudfunctions2_function.youtube_webhook.location
   service  = google_cloudfunctions2_function.youtube_webhook.name
   role     = "roles/run.invoker"
-  members  = ["allUsers"]
+  member   = "allUsers"
 }


### PR DESCRIPTION
## Summary
Fixes Terraform deployment error by changing IAM resource type from binding to member.

## Problem
PR #46 introduced a conflict between two IAM resources managing the same role:
- `google_cloud_run_service_iam_binding.webhook_invoker` (manages ALL members)
- `google_cloud_run_service_iam_member.scheduler_invoker` (manages ONE member)

This caused Terraform to fail with:
```
Error: Provider produced inconsistent result after apply
When applying changes to google_cloud_run_service_iam_member.scheduler_invoker
```

## Solution
- ✅ Change `iam_binding` → `iam_member` for public access
- ✅ Rename resource to `webhook_public_invoker` for clarity
- ✅ Both resources now use `iam_member` (additive, compatible)

## Technical Details
**IAM Resource Types:**
- `iam_binding`: Authoritative - replaces all members for a role
- `iam_member`: Additive - manages individual members for a role

Using both types for the same role creates conflicts. Solution: use `iam_member` for all grants to `roles/run.invoker`.

## Test Plan
- [x] Terraform validation passes locally
- [ ] CI tests pass
- [ ] Terraform deployment succeeds without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)